### PR TITLE
some updates for structs and vftables

### DIFF
--- a/src/structures.cpp
+++ b/src/structures.cpp
@@ -183,8 +183,8 @@ tid_t create_VT_struc(ea_t VT_ea, const char * basename, uval_t idx /*= BADADDR*
 		}
 	}
 	qstring name_vtbl = name_vt;
-	name_vtbl += "_vtbl";
-	name_vt += "_VT";
+	name_vtbl += "_vtbl_";
+	name_vt += "_vtbl";
 
 	{//TODO: do this better
 		ea_t fncea = get_ea(VT_ea);
@@ -218,6 +218,7 @@ tid_t create_VT_struc(ea_t VT_ea, const char * basename, uval_t idx /*= BADADDR*
 	if (newid == BADADDR) {
 		udt_type_data_t s;
 		s.taudt_bits |= TAUDT_UNALIGNED;
+		s.set_vftable(true);
 		if(!newstruc.create_udt(s) || newstruc.set_named_type(NULL, name_vt.c_str()) != TERR_OK)
 			return BADNODE;
 		newid = newstruc.get_tid();
@@ -227,6 +228,7 @@ tid_t create_VT_struc(ea_t VT_ea, const char * basename, uval_t idx /*= BADADDR*
 	}
 	newstruc.set_type_cmt(struccmt.c_str());
 #endif //IDA_SDK_VERSION < 900
+	set_vftable_ea(newid, VT_ea);
 	set_name(VT_ea, name_vtbl.c_str(), SN_FORCE);
 
 	ea_t ea = VT_ea;
@@ -322,7 +324,7 @@ int create_VT(tid_t parent, ea_t VT_ea)
 	type.get_type_by_tid(vt_struc_id);
 #endif //IDA_SDK_VERSION < 900
 	type = make_pointer(type);
-	add_vt_member(struc, 0, "VT", type, NULL);
+	add_vt_member(struc, 0, "__vftable", type, NULL);
 	return 1;
 }
 


### PR DESCRIPTION
structures:
- added fixed (`set_fixed()`) flag for ida 9 structures

vftables:
- use `set_vftable_ea`/`get_vftable_ea` api on top of //@0xaddress hacks

changed names so that they correspond to https://docs.hex-rays.com/user-guide/user-interface/menu-bar/view/c++-type-details
- VT ->  __vftable for vftable pointers
- _VT –> _vtbl for vftable names

use the set_vftable() to properly mark the vftables