### PR TITLE
small pull: make installation part readable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -141,6 +141,7 @@ class rangeset_t
 };
 ```
 
+## Install
  * Copy built binaries into `IDA_DIR/plugins` folder togeter with `apilist.txt` and `literal.txt` files from `hrtng/bin/plugins`
  * Profit
 


### PR DESCRIPTION
Because new user want to install plugins, not all people know how to install correctly. For example, they think there are no installation instruction, user may download the plugin and copy `hrtng.dll` to `IDA_DIR/plugins`

So, adding this fix may help some or most of new users.

## Before:
<img width="533" height="644" alt="waterfox_jeoA81GdGf" src="https://github.com/user-attachments/assets/a6e9506d-d009-4d17-8dca-9a0493237b11" />
<img width="840" height="470" alt="waterfox_5fnHpbxjEY" src="https://github.com/user-attachments/assets/e371c708-6aae-4451-8825-674046d314c5" />


## After:
<img width="674" height="653" alt="waterfox_9M0hZKfiNs" src="https://github.com/user-attachments/assets/1610b1d4-e302-4839-b89c-288832470356" />
