### PR TITLE
Add PyQt5 Compatibility Based on IDA Version

### DIFF
--- a/bin/plugins/notepad-md.py
+++ b/bin/plugins/notepad-md.py
@@ -10,10 +10,10 @@ import ida_kernwin
 import ida_nalt
 import ida_idaapi
 
-from idaapi import PluginForm
-# swap commented out PyQt5 to PySide6 in lines below for IDA < 9.2
-#from PyQt5 import QtWidgets
-from PySide6 import QtWidgets
+if float(ida_kernwin.get_kernel_version()) > 9.2:
+  from PySide6 import QtWidgets
+else:
+  from PyQt5 import QtWidgets
 
 mdnpForm = None
 


### PR DESCRIPTION
## Summary

This PR replaces the instructions that tell the user to replace PySide6 with PyQt5 with a IDA version check that loads the appropriate Qt library for a more painless integration for endusers.